### PR TITLE
feat: add GitHub Actions agent skill

### DIFF
--- a/.agentskills.yml
+++ b/.agentskills.yml
@@ -62,6 +62,12 @@ skills:
     languages: [go, golang]
     description: API documentation creation using godoc conventions
 
+  # CI/CD Skills
+  - name: github-actions
+    path: skills/github-actions
+    languages: [yaml, yml, shell, powershell]
+    description: GitHub Actions workflow design, security hardening, reuse, validation, and troubleshooting
+
   # Terraform Skills
   - name: terraform
     path: skills/terraform

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,9 @@ Available skills:
 - [C++ API Documentation](skills/cpp-api-documentation/SKILL.md)
   > Generates and maintains API documentation.
 
+- [GitHub Actions](skills/github-actions/SKILL.md)
+  > Designs, reviews, secures, and troubleshoots GitHub Actions workflows, reusable workflows, composite actions, credentials, runners, artifacts, and deployments.
+
 - [Terraform](skills/terraform/SKILL.md)
   > Guides Terraform/OpenTofu module design, testing, CI/CD, security, compliance, and state management with version-aware guardrails.
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,16 @@ Available skills can be activated by agents based on defined triggers and contex
 - [Go Skills](skills/README.md#12-go-skills)
   > Go unit testing, fuzz testing, benchmark testing, and API documentation skills.
 
-- [Terraform Skills](skills/README.md#13-terraform-skills)
+- [CI/CD Skills](skills/README.md#13-cicd-skills)
+  > GitHub Actions workflow design, security hardening, reuse, validation, and troubleshooting skills.
+
+- [Terraform Skills](skills/README.md#14-terraform-skills)
   > Terraform and OpenTofu module design, testing, CI/CD, security, compliance, and state management skills.
 
-- [Threat Modeling Skills](skills/README.md#14-threat-modeling-skills)
+- [Threat Modeling Skills](skills/README.md#15-threat-modeling-skills)
   > Threat modeling for OT/ICS systems.
 
-- [Documentation Skills](skills/README.md#15-documentation-skills)
+- [Documentation Skills](skills/README.md#16-documentation-skills)
   > Architecture Decision Records (ADR) creation and maintenance skills.
 
 ## 2. Contribute

--- a/skills/README.md
+++ b/skills/README.md
@@ -5,9 +5,10 @@ Agent skills are modular capabilities that AI agents can utilize to perform spec
 - [1. Agent Skills](#1-agent-skills)
   - [1.1. C++ Skills](#11-c-skills)
   - [1.2. Go Skills](#12-go-skills)
-  - [1.3. Terraform Skills](#13-terraform-skills)
-  - [1.4. Threat Modeling Skills](#14-threat-modeling-skills)
-  - [1.5. Documentation Skills](#15-documentation-skills)
+  - [1.3. CI/CD Skills](#13-cicd-skills)
+  - [1.4. Terraform Skills](#14-terraform-skills)
+  - [1.5. Threat Modeling Skills](#15-threat-modeling-skills)
+  - [1.6. Documentation Skills](#16-documentation-skills)
 - [2. References](#2-references)
 
 ## 1. Agent Skills
@@ -45,17 +46,22 @@ Skills are documented in individual `SKILL.md` files located in appropriate subd
 - [Go API Documentation](go-api-documentation/SKILL.md)
   > API documentation creation using godoc conventions and best practices for Go projects.
 
-### 1.3. Terraform Skills
+### 1.3. CI/CD Skills
+
+- [GitHub Actions](github-actions/SKILL.md)
+  > Designs, reviews, secures, and troubleshoots GitHub Actions workflows, reusable workflows, composite actions, runners, credentials, artifacts, and deployments.
+
+### 1.4. Terraform Skills
 
 - [Terraform](terraform/SKILL.md)
   > External Terraform and OpenTofu guidance for module design, testing, CI/CD, security, compliance, and state management.
 
-### 1.4. Threat Modeling Skills
+### 1.5. Threat Modeling Skills
 
 - [Threat Modeling ICS](threat-modeling-ics/SKILL.md)
   > Threat modeling for OT/ICS systems using Microsoft TMT, STRIDE, MITRE ATT&CK for ICS, CWE, and CVSS v4.0.
 
-### 1.5. Documentation Skills
+### 1.6. Documentation Skills
 
 - [Architecture Decision Records (ADR)](adr/SKILL.md)
   > Creates and maintains Architecture Decision Records following a structured format with State, Context, Decision, Considered, Consequences, Implementation, and References sections.

--- a/skills/github-actions/SKILL.md
+++ b/skills/github-actions/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: github-actions
+description: >-
+  Designs, reviews, secures, and troubleshoots GitHub Actions workflows, reusable workflows, and composite actions. Use when creating or modifying files under `.github/workflows` or `.github/actions`, diagnosing workflow failures, hardening permissions and secrets, implementing CI/CD, or discussing GitHub Actions events, runners, matrices, caching, artifacts, environments, OIDC, or workflow reuse.
+license: Apache-2.0
+metadata:
+  version: "1.0.0"
+---
+
+# GitHub Actions
+
+Instructions for AI agents designing, reviewing, securing, and troubleshooting GitHub Actions automation.
+
+- [1. Response Contract](#1-response-contract)
+- [2. Workflow](#2-workflow)
+- [3. Diagnose Before Generating](#3-diagnose-before-generating)
+- [4. When to Use This Skill](#4-when-to-use-this-skill)
+- [5. Non-Negotiable Guardrails](#5-non-negotiable-guardrails)
+- [6. Architecture Principles](#6-architecture-principles)
+- [7. Authoring Standards](#7-authoring-standards)
+- [8. Security Model](#8-security-model)
+- [9. Reliability and Efficiency](#9-reliability-and-efficiency)
+- [10. Validation](#10-validation)
+- [11. Review Checklist](#11-review-checklist)
+- [12. References](#12-references)
+
+## 1. Response Contract
+
+Every GitHub Actions response must include:
+
+1. **Execution context**
+   > Identify the triggering event, trusted and untrusted inputs, runner type, operating systems, repository visibility, branch protections, required checks, and deployment environments. State assumptions when context is unavailable.
+
+2. **Permissions and credential model**
+   > State the required `GITHUB_TOKEN` permissions, whether secrets are available, whether OIDC is used, and which jobs cross a trust boundary. Default to no permissions and grant only the minimum required per job.
+
+3. **Chosen design and trade-offs**
+   > Explain the job graph, reuse boundary, caching or artifact strategy, concurrency behavior, and any portability or maintainability trade-offs.
+
+4. **Validation plan**
+   > Provide exact static checks and relevant GitHub-side verification steps. Include negative-path testing for event filters, fork pull requests, cancellation, retries, and deployment protections when applicable.
+
+5. **Operational notes**
+   > Describe rollout, observability, failure recovery, and rollback for workflows that publish, deploy, mutate repository state, or manage infrastructure.
+
+Never treat workflow YAML as ordinary configuration. It is executable code with access to repository content, tokens, secrets, artifacts, caches, runners, and external systems.
+
+## 2. Workflow
+
+1. **Inspect repository policy**
+   > Read `AGENTS.md`, `CONTRIBUTING.md`, existing workflows, organization conventions, branch protection assumptions, and dependency update configuration before generating changes.
+
+2. **Classify the automation**
+   > Determine whether the task is CI validation, release automation, deployment, repository maintenance, security scanning, a reusable workflow, a composite action, or workflow troubleshooting.
+
+3. **Map trust boundaries**
+   > Identify which event data or checked-out code may be controlled by an untrusted contributor. Treat pull request metadata, issue bodies, comments, branch names, commit messages, artifacts, and cache contents as untrusted unless provenance is established.
+
+4. **Design permissions first**
+   > Define `permissions: {}` at workflow scope where practical, then grant the smallest permission set to the specific job that requires it. Keep `id-token: write`, package publishing, pull-request writes, and deployment credentials isolated.
+
+5. **Choose the reuse boundary**
+   > Use reusable workflows for multi-job orchestration, composite actions for repeated step sequences, workflow templates for discoverable starter workflows, and ordinary jobs for local logic that does not justify an abstraction.
+
+6. **Implement deterministically**
+   > Pin external actions and cross-repository reusable workflows to full-length commit SHAs, specify runner labels deliberately, set timeouts, make shell behavior explicit, and avoid implicit credential persistence.
+
+7. **Validate in layers**
+   > Parse YAML, lint Actions semantics, lint embedded shell, scan for workflow security weaknesses, inspect the rendered job graph, and execute representative GitHub-hosted runs.
+
+8. **Review operational behavior**
+   > Verify cancellation, concurrency, retry safety, artifact retention, cache invalidation, deployment approvals, and rollback before finalizing.
+
+9. **Emit the Response Contract**
+   > Summarize context, permissions, design, validation, and operations in the final response.
+
+## 3. Diagnose Before Generating
+
+| Category | Common symptoms or request | Primary reference |
+|---|---|---|
+| Workflow syntax and event routing | Invalid YAML, unexpected triggers, skipped jobs, path or branch filters, expression errors | [Workflow Authoring](references/workflow-authoring.md) |
+| Job architecture | Job dependencies, matrices, services, containers, concurrency, timeouts, outputs | [Workflow Authoring](references/workflow-authoring.md) |
+| Security hardening | Excessive permissions, unsafe events, script injection, unpinned actions, secret leakage, runner compromise | [Security Hardening](references/security-hardening.md) |
+| Cloud authentication and deployment | Long-lived cloud secrets, OIDC, environments, approvals, deployment serialization | [Security Hardening](references/security-hardening.md) |
+| Reuse and governance | Reusable workflows, composite actions, templates, organization-wide CI, versioning | [Reuse and Architecture](references/reuse-and-architecture.md) |
+| Validation and failures | Static linting, failed runs, flaky jobs, logs, reruns, local emulation, debugging | [Testing and Troubleshooting](references/testing-and-troubleshooting.md) |
+
+Load only the references needed for the task. Load multiple references when a change crosses architecture, security, and operational boundaries.
+
+## 4. When to Use This Skill
+
+**Activate when:**
+
+- Creating, reviewing, or modifying workflow files in `.github/workflows/`.
+- Creating or reviewing composite actions under `.github/actions/`.
+- Designing CI, release, deployment, maintenance, or security automation.
+- Implementing reusable workflows, matrices, caching, artifacts, environments, or OIDC.
+- Troubleshooting workflow syntax, event behavior, runner failures, permissions, secrets, or expressions.
+- Reviewing workflow supply-chain and untrusted-input risks.
+
+**Do not use for:**
+
+- GitHub API integration that does not run through GitHub Actions.
+- General shell scripting without workflow context.
+- CI systems other than GitHub Actions, except for migration planning.
+- Creating standalone JavaScript or Docker actions when the request is primarily action implementation rather than workflow integration; use the relevant language or container skill alongside this skill.
+
+## 5. Non-Negotiable Guardrails
+
+- Never execute or check out untrusted pull request code in a privileged `pull_request_target` or privileged `workflow_run` context.
+- Never interpolate untrusted context values directly into `run:` scripts. Pass them through environment variables or structured action inputs and quote them correctly.
+- Never grant write permissions at workflow scope when only one job requires them.
+- Never add `id-token: write` outside the job that performs OIDC authentication.
+- Never store long-lived cloud credentials when the target supports GitHub OIDC.
+- Never print secrets, tokens, credentials, signed URLs, or sensitive command output. Treat redaction as defense in depth, not a guarantee.
+- Never use untrusted artifacts or caches in a privileged job without validation and provenance controls.
+- Never use self-hosted runners for untrusted public pull requests. Treat persistent or broadly networked runners as high-impact assets.
+- Never reference an external action or cross-repository reusable workflow by a mutable branch or tag in security-sensitive workflows. Use a verified full-length commit SHA and retain a version comment for maintainability.
+- Never deploy or publish from an unreviewed build when provenance, approvals, or branch protections are required.
+
+## 6. Architecture Principles
+
+### 6.1. Separate Validation from Privilege
+
+Use unprivileged workflows for builds and tests. Place repository writes, publishing, or deployment in separate jobs or workflows that consume reviewed and verified outputs.
+
+```plaintext
+untrusted change
+    |
+    v
+read-only validation --> reviewed commit or approved environment
+                              |
+                              v
+                     privileged publish/deploy
+```
+
+Privilege separation must include event selection, token permissions, secret availability, artifact provenance, and runner isolation. A separate job alone is insufficient when it consumes attacker-controlled state.
+
+### 6.2. Prefer Explicit Job Graphs
+
+- Model dependencies with `needs` rather than relying on file order.
+- Keep build, test, package, publish, and deploy responsibilities distinct.
+- Use job outputs for small control data and artifacts for files.
+- Keep the critical path short; parallelize independent jobs.
+- Use a final aggregation job when branch protection requires one stable check across conditional or matrix jobs.
+
+### 6.3. Reuse at Stable Boundaries
+
+| Need | Preferred mechanism |
+|---|---|
+| Repeated steps within or across repositories | Composite action |
+| Repeated multi-job pipeline | Reusable workflow |
+| Discoverable starter configuration | Workflow template |
+| Repository-specific orchestration | Ordinary workflow |
+| Shared script with independent tests | Versioned script or package invoked by workflows |
+
+Avoid abstractions that hide permissions, event assumptions, environment use, or deployment behavior from callers.
+
+### 6.4. Treat Workflows as Production Software
+
+- Keep interfaces typed and documented.
+- Version shared automation.
+- Review dependency updates.
+- Test failure and cancellation paths.
+- Preserve logs and evidence appropriate to the risk level.
+- Require code ownership for workflow and shared automation changes where governance permits.
+
+## 7. Authoring Standards
+
+### 7.1. File and Identifier Naming
+
+- Use lowercase kebab-case file names such as `pull-request-ci.yml` and `release-package.yml`.
+- Use concise workflow names that describe the outcome, not the implementation.
+- Use stable, machine-readable job IDs and human-readable job names.
+- Name steps that perform meaningful work; omit names only for self-evident setup steps.
+- Use explicit `run-name` when manual, release, or deployment runs need operator context.
+
+### 7.2. Trigger Design
+
+- Specify activity types and branch, tag, or path filters deliberately.
+- Prefer `pull_request` for validating pull requests.
+- Use `push` for trusted branch and tag automation.
+- Use `workflow_dispatch` for explicit operator-driven actions with typed inputs.
+- Use `schedule` only when timing drift is acceptable and idempotency is designed.
+- Use `workflow_run` only with a documented trust model for the upstream workflow and its artifacts.
+- Avoid `pull_request_target` unless repository-base context is essential and no untrusted code is executed.
+
+### 7.3. Permissions
+
+Start with no workflow-level permissions when compatible with the design:
+
+```yaml
+permissions: {}
+```
+
+Grant permissions per job:
+
+```yaml
+jobs:
+  test:
+    permissions:
+      contents: read
+
+  publish:
+    permissions:
+      contents: read
+      packages: write
+```
+
+Do not grant `contents: write`, `pull-requests: write`, `issues: write`, `packages: write`, `security-events: write`, or `id-token: write` without a specific operation that requires it.
+
+### 7.4. External Dependencies
+
+Use full-length commit SHAs for external actions and cross-repository reusable workflows. Preserve the release identifier in a comment so dependency automation and reviewers can understand the intended version.
+
+```yaml
+- uses: actions/checkout@<full-length-commit-sha> # v4
+  with:
+    persist-credentials: false
+```
+
+Audit the source, publisher, required permissions, inputs, outputs, runtime, and release history before adoption. Configure Dependabot or an equivalent updater for GitHub Actions dependencies.
+
+### 7.5. Shell and Expression Safety
+
+- Make the shell explicit when behavior matters.
+- Use strict error handling and quote expansions.
+- Pass context values through `env` rather than embedding expressions in shell source.
+- Use `$GITHUB_OUTPUT`, `$GITHUB_ENV`, and `$GITHUB_PATH` instead of deprecated workflow commands.
+- Use multiline delimiters only when the content is trusted or the delimiter is generated safely.
+- Keep complex logic in tested scripts rather than large inline `run:` blocks.
+
+### 7.6. Time and Resource Bounds
+
+- Set `timeout-minutes` for every job that can hang or consume costly runners.
+- Set step timeouts for network, deployment, and teardown operations when supported by the design.
+- Use `strategy.max-parallel` to control external-system load.
+- Use concurrency groups for supersedable validation and serialized deployment.
+- Set artifact retention intentionally and avoid uploading unnecessary files.
+
+## 8. Security Model
+
+### 8.1. Trust Classification
+
+| Source | Default trust |
+|---|---|
+| Code from the default branch after required review | Trusted according to repository policy |
+| Pull request head from a fork | Untrusted |
+| Pull request metadata, issue content, comments, branch names, commit messages | Untrusted |
+| External action or reusable workflow | Third-party executable dependency |
+| Artifact from another workflow | Untrusted until producer and content are verified |
+| Cache restored across trust boundaries | Potentially attacker-influenced |
+| Self-hosted runner state and network | Sensitive persistent execution environment |
+| Repository, environment, or organization secret | Sensitive credential material |
+
+### 8.2. Credential Hierarchy
+
+Prefer, in order:
+
+1. Job-scoped `GITHUB_TOKEN` with minimum permissions.
+2. OIDC-issued short-lived credentials with restrictive subject and audience conditions.
+3. GitHub App installation tokens with narrow repository and permission scope.
+4. Fine-grained personal access tokens only when platform limitations require them.
+5. Classic personal access tokens or long-lived cloud keys only as an explicitly documented exception.
+
+### 8.3. Deployment Controls
+
+- Use protected environments for production and other sensitive targets.
+- Require reviewers and branch or tag restrictions where available.
+- Put credentials in the environment rather than broad repository scope when access should be gated.
+- Use concurrency to prevent overlapping deployments to the same target.
+- Separate build and deploy; deploy the exact reviewed artifact rather than rebuilding after approval.
+- Record artifact digest, source commit, workflow identity, environment, and deployment result.
+
+See [Security Hardening](references/security-hardening.md) for threat-specific controls and examples.
+
+## 9. Reliability and Efficiency
+
+- Use matrices for supported platform or version combinations, not for unrelated tasks.
+- Use `fail-fast: false` when all matrix results are diagnostically valuable; keep the default when early cancellation saves substantial cost.
+- Cache dependency downloads, not build outputs that require provenance or long-term retention.
+- Key caches with lock files and relevant toolchain or platform dimensions.
+- Use artifacts to pass immutable files between jobs and retain evidence.
+- Design release, publish, and deploy jobs to be idempotent or safely resumable.
+- Use concurrency with `cancel-in-progress: true` for superseded branch validation; do not cancel irreversible operations without an explicit recovery design.
+- Prefer GitHub-hosted ephemeral runners unless hardware, network, compliance, or performance requirements justify self-hosting.
+- Pin runner operating systems when reproducibility is more important than automatic image updates; otherwise monitor image changes.
+
+## 10. Validation
+
+Use the validation ladder appropriate to the change:
+
+1. **Structure**
+   > Parse YAML 1.2, verify files are under `.github/workflows/`, check frontmatter or metadata for composite actions, and validate referenced local paths.
+
+2. **Actions semantics**
+   > Run `actionlint` or an equivalent semantic linter against every changed workflow.
+
+3. **Embedded code**
+   > Run ShellCheck, PSScriptAnalyzer, language linters, and unit tests for referenced scripts or actions.
+
+4. **Security**
+   > Review permissions, action pinning, event trust, untrusted expressions, secrets, OIDC conditions, caches, artifacts, and runners. Use CodeQL workflow analysis, OpenSSF Scorecard, or an equivalent workflow security scanner where available.
+
+5. **GitHub execution**
+   > Run representative events on GitHub-hosted runners. Test successful, failing, cancelled, rerun, fork, and protected-environment paths as applicable.
+
+6. **Operational evidence**
+   > Verify logs, summaries, artifacts, attestations, retention, deployment records, and rollback instructions.
+
+See [Testing and Troubleshooting](references/testing-and-troubleshooting.md) for commands and failure playbooks.
+
+## 11. Review Checklist
+
+Before finalizing a GitHub Actions change, verify:
+
+- [ ] Events and filters match the intended execution set.
+- [ ] Fork and untrusted-input behavior is explicitly safe.
+- [ ] Workflow-level permissions are empty or read-only.
+- [ ] Each job has only the permissions it needs.
+- [ ] Secrets are scoped and are not exposed to untrusted code.
+- [ ] OIDC replaces long-lived cloud credentials where supported.
+- [ ] External actions and workflows are pinned to verified full commit SHAs.
+- [ ] Checkout credential persistence is disabled unless a later Git operation requires it.
+- [ ] Jobs and network operations have timeouts.
+- [ ] Concurrency behavior is intentional.
+- [ ] Caches and artifacts do not cross trust boundaries unsafely.
+- [ ] Reusable workflow inputs, secrets, outputs, and permissions form a documented contract.
+- [ ] Self-hosted runner exposure is justified and isolated.
+- [ ] Static linting and embedded-script checks pass.
+- [ ] Required checks, deployment approvals, retries, cancellation, and rollback have been considered.
+
+## 12. References
+
+- [Workflow Authoring](references/workflow-authoring.md)
+- [Security Hardening](references/security-hardening.md)
+- [Reuse and Architecture](references/reuse-and-architecture.md)
+- [Testing and Troubleshooting](references/testing-and-troubleshooting.md)
+- GitHub Docs: [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+- GitHub Docs: [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- GitHub Docs: [OpenID Connect](https://docs.github.com/en/actions/concepts/security/openid-connect)
+- GitHub Docs: [Reuse workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)

--- a/skills/github-actions/references/reuse-and-architecture.md
+++ b/skills/github-actions/references/reuse-and-architecture.md
@@ -1,0 +1,376 @@
+# Reuse and Architecture
+
+> **Part of:** [GitHub Actions](../SKILL.md)
+> **Purpose:** Reusable workflows, composite actions, templates, contracts, versioning, and organization governance
+
+- [1. Reuse Decision Matrix](#1-reuse-decision-matrix)
+- [2. Reusable Workflows](#2-reusable-workflows)
+- [3. Composite Actions](#3-composite-actions)
+- [4. Workflow Templates](#4-workflow-templates)
+- [5. Contracts and Compatibility](#5-contracts-and-compatibility)
+- [6. Secrets and Permissions](#6-secrets-and-permissions)
+- [7. Versioning and Distribution](#7-versioning-and-distribution)
+- [8. Organization Architecture](#8-organization-architecture)
+- [9. Migration Strategy](#9-migration-strategy)
+- [10. Common Mistakes](#10-common-mistakes)
+- [11. References](#11-references)
+
+## 1. Reuse Decision Matrix
+
+| Mechanism | Best for | Boundary | Limitations |
+|---|---|---|---|
+| Reusable workflow | Multi-job pipelines, shared permissions and orchestration | Called at job level | Caller cannot insert arbitrary steps into the called job |
+| Composite action | Repeated step sequence | Called within a job step | Shares caller runner and job permissions; no independent jobs |
+| Workflow template | Discoverable starter workflow | Copied into consuming repository | Copies diverge unless separately maintained |
+| Local script or package | Complex tested logic | Called by steps or actions | Requires language/runtime lifecycle |
+| Ordinary workflow | Repository-specific orchestration | Entire workflow | Duplication if organization-wide behavior repeats |
+
+Use the smallest abstraction that makes the contract clearer. Do not reuse merely to reduce line count.
+
+## 2. Reusable Workflows
+
+Reusable workflows are stored directly in `.github/workflows/` and expose `workflow_call`.
+
+```yaml
+name: Reusable CI
+
+on:
+  workflow_call:
+    inputs:
+      runtime:
+        description: Runtime version
+        required: true
+        type: string
+      upload-coverage:
+        description: Upload coverage report
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      coverage-token:
+        description: Coverage service token
+        required: false
+    outputs:
+      artifact-name:
+        description: Name of the generated package artifact
+        value: ${{ jobs.build.outputs.artifact-name }}
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    outputs:
+      artifact-name: ${{ steps.meta.outputs.artifact-name }}
+    steps:
+      - uses: actions/checkout@<full-length-commit-sha> # v4
+        with:
+          persist-credentials: false
+      - id: meta
+        run: echo "artifact-name=package-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+```
+
+Caller:
+
+```yaml
+jobs:
+  ci:
+    uses: example/automation/.github/workflows/ci.yml@<full-length-commit-sha> # v2
+    permissions:
+      contents: read
+    with:
+      runtime: "22"
+      upload-coverage: true
+    secrets:
+      coverage-token: ${{ secrets.COVERAGE_TOKEN }}
+```
+
+### 2.1. Reusable Workflow Rules
+
+- Call reusable workflows at the job level with `jobs.<job_id>.uses`.
+- Type every input as `boolean`, `number`, or `string`.
+- Document defaults, allowed values, security assumptions, and output semantics.
+- Keep environment selection explicit and auditable.
+- Use a matrix in the caller when one reusable workflow should run for multiple targets.
+- Keep nesting shallow even though GitHub supports multiple levels.
+- Remember that permissions can be maintained or reduced through a call chain, not elevated by a nested workflow.
+- Pass secrets only to the direct workflow that needs them.
+
+## 3. Composite Actions
+
+A composite action packages repeated steps and executes within the caller's job, runner, workspace, network, token permissions, and secret exposure.
+
+`action.yml`:
+
+```yaml
+name: Setup Project
+description: Install the toolchain and project dependencies
+
+inputs:
+  runtime:
+    description: Runtime version
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@<full-length-commit-sha> # v4
+      with:
+        node-version: ${{ inputs.runtime }}
+        cache: npm
+    - shell: bash
+      run: npm ci
+```
+
+Caller:
+
+```yaml
+- uses: ./.github/actions/setup-project
+  with:
+    runtime: "22"
+```
+
+### 3.1. Composite Action Rules
+
+- Define descriptions for the action and every input and output.
+- Specify `shell` for every `run` step.
+- Use `$GITHUB_ACTION_PATH` to locate files bundled with the action.
+- Do not assume repository root or caller working directory unless documented.
+- Do not hide permissions or secret requirements; composite actions inherit the caller's job context.
+- Keep orchestration, environment protection, matrices, and services in workflows rather than composite actions.
+- Use tested scripts for complex logic inside the action.
+
+## 4. Workflow Templates
+
+Workflow templates help repositories create an initial workflow from an organization-controlled template. Use them when repositories need discoverable, customizable starting points rather than centrally enforced behavior.
+
+Templates should:
+
+- Include comments identifying required customization.
+- Use safe permissions and pinned dependencies.
+- Avoid organization-specific secrets that are not universally available.
+- Link to maintenance and support documentation.
+- Include a configuration file with applicable repository categories where required.
+
+Do not use templates when a centrally updated reusable workflow is the actual requirement.
+
+## 5. Contracts and Compatibility
+
+Treat shared workflow and action interfaces as APIs.
+
+### 5.1. Input Contract
+
+For each input, define:
+
+- Name and type.
+- Required or optional status.
+- Default.
+- Allowed values and validation.
+- Whether the value may be untrusted.
+- Whether it influences permissions, environments, runners, commands, paths, or cloud roles.
+
+Do not allow caller input to select arbitrary runners, environments, commands, action references, or privileged roles without an allow list.
+
+### 5.2. Secret Contract
+
+For each secret, define:
+
+- Purpose.
+- Minimum external permissions.
+- Source scope: repository, environment, or organization.
+- Jobs and steps that receive it.
+- Whether OIDC can replace it.
+- Rotation and failure behavior.
+
+Prefer named secret passing to `secrets: inherit`. Use inheritance only when the caller and callee are tightly governed and the expanded secret surface is understood.
+
+### 5.3. Output Contract
+
+Outputs should be:
+
+- Small.
+- Non-sensitive.
+- Deterministic.
+- Documented for empty, skipped, and failed cases.
+
+Use artifacts for files and retain their digest and provenance where appropriate.
+
+### 5.4. Compatibility
+
+Classify changes:
+
+| Change | Compatibility |
+|---|---|
+| Add optional input with safe default | Usually backward compatible |
+| Add output | Usually backward compatible |
+| Change default behavior | Potentially breaking |
+| Rename or remove input, secret, or output | Breaking |
+| Increase required permissions | Security-relevant and potentially breaking |
+| Change runner or environment assumptions | Potentially breaking |
+| Change artifact name or format | Breaking for consumers |
+
+Publish migration notes for breaking changes.
+
+## 6. Secrets and Permissions
+
+### 6.1. Permission Propagation
+
+The caller should define permissions for the reusable-workflow job. The called workflow cannot elevate beyond what the caller grants.
+
+```yaml
+jobs:
+  release:
+    permissions:
+      contents: write
+      id-token: write
+    uses: example/automation/.github/workflows/release.yml@<full-length-commit-sha> # v3
+```
+
+The called workflow should still document and declare its expected permissions so callers can review the contract.
+
+### 6.2. Secret Propagation
+
+Secrets are passed only to directly called workflows. In a chain A to B to C, B must explicitly pass a secret onward to C.
+
+Use named passing:
+
+```yaml
+secrets:
+  registry-token: ${{ secrets.REGISTRY_TOKEN }}
+```
+
+Avoid broad inheritance for reusable workflows that call other workflows or accept untrusted inputs.
+
+### 6.3. Environment Secrets
+
+Environment secrets are selected by the job's `environment` in the called workflow. They are not passed through `on.workflow_call`. Keep environment ownership and deployment behavior visible to callers.
+
+## 7. Versioning and Distribution
+
+### 7.1. References
+
+For cross-repository use, callers should pin to a full commit SHA:
+
+```yaml
+uses: example/automation/.github/workflows/ci.yml@<full-length-commit-sha> # v2.4.1
+```
+
+Maintain semantic release tags for discoverability, but resolve consumption to a verified SHA. Use dependency automation to update the SHA and version comment together.
+
+### 7.2. Release Process
+
+A shared automation release should include:
+
+1. Static and security validation.
+2. Integration tests in representative consumer repositories.
+3. Compatibility review.
+4. Versioned release notes.
+5. Immutable commit reference.
+6. Migration guidance for breaking changes.
+7. Deprecation window for widely used interfaces.
+
+### 7.3. Local Reuse
+
+Use relative paths for same-repository reusable workflows and composite actions when caller and implementation must evolve atomically:
+
+```yaml
+uses: ./.github/workflows/ci.yml
+```
+
+```yaml
+uses: ./.github/actions/setup-project
+```
+
+The reusable workflow path must be a direct child of `.github/workflows/`; subdirectories are not supported.
+
+## 8. Organization Architecture
+
+A mature organization can structure automation in layers:
+
+```plaintext
+organization policy and runner governance
+                |
+                v
+central reusable workflows and composite actions
+                |
+                v
+repository caller workflows with minimal orchestration
+                |
+                v
+project scripts, tests, and deployment tooling
+```
+
+### 8.1. Central Layer
+
+Central automation should provide:
+
+- Secure defaults and minimum permissions.
+- Standard build, test, scan, package, and deploy workflows.
+- OIDC patterns and protected-environment contracts.
+- Approved action dependencies and update automation.
+- Common summaries, artifacts, attestations, and observability.
+- Versioning, support ownership, and deprecation policy.
+
+### 8.2. Repository Layer
+
+Repository callers should define:
+
+- Events and repository-specific filters.
+- Required workflow inputs.
+- Explicit permissions and secrets.
+- Repository-specific environments and deployment targets.
+- Project scripts and test commands.
+
+### 8.3. Governance
+
+Use repository and organization settings to complement workflow files:
+
+- Restrict allowed actions and reusable workflows.
+- Require full-SHA pinning where supported.
+- Set default `GITHUB_TOKEN` permissions to read-only.
+- Protect workflow paths with CODEOWNERS.
+- Restrict self-hosted runner groups.
+- Configure environment protections.
+- Enable dependency graph, Dependabot, code scanning, and audit logging.
+
+## 9. Migration Strategy
+
+To consolidate duplicated workflows:
+
+1. Inventory workflows and group them by behavior.
+2. Identify stable common stages and repository-specific variation.
+3. Define typed inputs, named secrets, outputs, permissions, and runner assumptions.
+4. Create a reusable workflow or composite action with integration tests.
+5. Migrate one low-risk repository.
+6. Compare checks, artifacts, duration, permissions, and failure behavior.
+7. Publish a versioned release.
+8. Migrate remaining repositories incrementally.
+9. Remove copied logic only after consumers are verified.
+10. Add dependency update and deprecation processes.
+
+Avoid a large centralization change that simultaneously alters permissions, runners, toolchains, and deployment behavior.
+
+## 10. Common Mistakes
+
+- Creating a reusable workflow for a three-step sequence better represented by a composite action.
+- Creating a composite action that hides deployment environments or broad permissions.
+- Using untyped or undocumented inputs.
+- Allowing input to choose arbitrary shell commands or runner labels.
+- Using `secrets: inherit` by default.
+- Assuming environment secrets can be passed through `workflow_call`.
+- Pinning central workflows to a mutable `main` branch.
+- Introducing breaking defaults without versioning.
+- Nesting workflows until permissions and data flow become difficult to audit.
+- Centralizing project-specific logic that should remain a tested repository script.
+- Treating copied workflow templates as centrally updated dependencies.
+
+## 11. References
+
+- GitHub Docs: [Reuse workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
+- GitHub Docs: [Reusing workflow configurations](https://docs.github.com/en/actions/concepts/workflows-and-actions/reusing-workflow-configurations)
+- GitHub Docs: [Creating a composite action](https://docs.github.com/en/actions/tutorials/creating-a-composite-action)
+- GitHub Docs: [Creating workflow templates for an organization](https://docs.github.com/en/actions/how-tos/reuse-automations/create-workflow-templates)
+- GitHub Docs: [Sharing actions and workflows from a private repository](https://docs.github.com/en/actions/how-tos/reuse-automations/share-across-private-repositories)

--- a/skills/github-actions/references/security-hardening.md
+++ b/skills/github-actions/references/security-hardening.md
@@ -1,0 +1,426 @@
+# Security Hardening
+
+> **Part of:** [GitHub Actions](../SKILL.md)
+> **Purpose:** Threat modeling, permissions, untrusted input, supply-chain security, credentials, runners, artifacts, and deployments
+
+- [1. Threat Model](#1-threat-model)
+- [2. Token Permissions](#2-token-permissions)
+- [3. Untrusted Input and Script Injection](#3-untrusted-input-and-script-injection)
+- [4. Pull Request Event Safety](#4-pull-request-event-safety)
+- [5. Actions and Workflow Dependencies](#5-actions-and-workflow-dependencies)
+- [6. Secrets, OIDC, and Environments](#6-secrets-oidc-and-environments)
+- [7. Runners](#7-runners)
+- [8. Caches and Artifacts](#8-caches-and-artifacts)
+- [9. Release and Deployment Integrity](#9-release-and-deployment-integrity)
+- [10. Security Review Procedure](#10-security-review-procedure)
+- [11. Common Mistakes](#11-common-mistakes)
+- [12. References](#12-references)
+
+## 1. Threat Model
+
+A GitHub Actions threat model must identify:
+
+- Who can trigger the workflow.
+- Who controls the checked-out commit.
+- Which event fields are attacker-controlled.
+- Which token permissions are available.
+- Which repository, organization, and environment secrets are available.
+- Which external actions, workflows, containers, and packages execute.
+- Whether caches, artifacts, or outputs cross workflow boundaries.
+- Whether the runner is ephemeral or persistent.
+- Which networks, cloud accounts, registries, signing systems, and deployment targets are reachable.
+- Which repository settings, branches, tags, releases, issues, pull requests, packages, or security alerts the workflow can modify.
+
+### 1.1. Trust Boundary Table
+
+| Boundary | Threat | Required control |
+|---|---|---|
+| Fork pull request to repository workflow | Arbitrary code and metadata | Read-only token, no secrets, ephemeral runner |
+| Unprivileged build to privileged deploy | Artifact substitution or tampering | Provenance verification, digest binding, approval |
+| Workflow to third-party action | Supply-chain compromise | Source review, full-SHA pin, minimum permissions |
+| Workflow to cloud provider | Credential theft or over-broad role | OIDC, restrictive claims, short session, least privilege |
+| Workflow to self-hosted runner | Persistence and lateral movement | Isolation, ephemeral lifecycle, restricted network, runner groups |
+| Cache or artifact producer to consumer | Poisoning, path traversal, unexpected content | Scope, validate, verify producer and digest |
+
+## 2. Token Permissions
+
+### 2.1. Default Deny
+
+Prefer:
+
+```yaml
+permissions: {}
+```
+
+Then add permissions to individual jobs. A job that checks out code normally requires only:
+
+```yaml
+permissions:
+  contents: read
+```
+
+### 2.2. Permission Review
+
+| Permission | Typical legitimate operation | Review concern |
+|---|---|---|
+| `contents: write` | Create tags, releases, or commits | Repository takeover if untrusted code executes |
+| `pull-requests: write` | Comment, label, or update pull requests | Spam, metadata manipulation, approval confusion |
+| `issues: write` | Create or update issues | Untrusted content propagation and spam |
+| `packages: write` | Publish packages | Supply-chain compromise |
+| `security-events: write` | Upload code-scanning results | Usually limited to security analysis jobs |
+| `id-token: write` | Request an OIDC token | Enables cloud or service authentication according to trust policy |
+| `attestations: write` | Create artifact attestations | Bind only to reviewed artifacts and trusted workflows |
+| `actions: write` | Manage workflow runs | Broad automation control; rarely needed |
+
+`id-token: write` does not itself grant cloud access, but it allows the job to request an identity token. The external trust policy determines what that identity can obtain.
+
+### 2.3. Token Selection
+
+Use the narrowest viable credential:
+
+1. `GITHUB_TOKEN` with job-level permissions.
+2. OIDC-issued external credentials.
+3. GitHub App installation token.
+4. Fine-grained personal access token.
+5. Classic personal access token only as a documented exception.
+
+Do not use a personal token merely to bypass permission design or event restrictions.
+
+## 3. Untrusted Input and Script Injection
+
+GitHub expressions are evaluated before an inline shell script is generated. Direct interpolation can turn data into executable syntax.
+
+### 3.1. Unsafe
+
+```yaml
+- name: Check title
+  run: echo "${{ github.event.pull_request.title }}"
+```
+
+A malicious title can escape the intended quoting and inject shell commands.
+
+### 3.2. Safer Inline Script
+
+```yaml
+- name: Check title
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: printf '%s\n' "$PR_TITLE"
+```
+
+The expression becomes an environment value rather than shell source. Shell quoting and downstream validation remain necessary.
+
+### 3.3. Preferred Structured Input
+
+Use a maintained action or tested script that accepts the value as a structured input or argument.
+
+```yaml
+- name: Validate title
+  uses: example/validate-title@<full-length-commit-sha> # v2
+  with:
+    title: ${{ github.event.pull_request.title }}
+```
+
+The action itself must still treat the input as untrusted.
+
+### 3.4. Untrusted Context Examples
+
+Treat these as untrusted when contributor-controlled:
+
+- Pull request title, body, labels, and head branch.
+- Issue title, body, labels, and comments.
+- Commit messages and author fields.
+- Release or discussion content.
+- File names, archive entries, package metadata, and test names.
+- Manual input provided by an operator.
+- Matrix values generated from repository content or API responses.
+
+Never use untrusted values directly in commands, file paths, SQL, regular expressions, URLs, concurrency groups that carry authority, or cloud role selectors without validation.
+
+## 4. Pull Request Event Safety
+
+### 4.1. `pull_request`
+
+Use for building and testing proposed code.
+
+Expected properties:
+
+- The code may be attacker-controlled.
+- Fork pull requests normally receive a read-only token.
+- Repository secrets are not exposed to fork pull requests.
+- The runner must be treated as compromised after executing the code.
+
+Keep these jobs read-only and ephemeral.
+
+### 4.2. `pull_request_target`
+
+This event runs in the context of the base repository and can receive elevated permissions and secrets. Use it only for operations on trusted base-repository code, such as labeling or commenting based on validated metadata.
+
+Never:
+
+- Check out the pull request head.
+- Execute scripts from the pull request.
+- Install dependencies from the pull request.
+- Build a container or package from the pull request.
+- Restore an attacker-controlled cache and then run privileged code.
+- Download an unverified artifact produced from the pull request and execute it.
+
+Safe pattern:
+
+```yaml
+name: Pull Request Metadata
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions: {}
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Apply validated metadata rule
+        uses: example/metadata-policy@<full-length-commit-sha> # v1
+        with:
+          title: ${{ github.event.pull_request.title }}
+```
+
+This pattern does not check out or execute pull request code.
+
+### 4.3. `workflow_run`
+
+A privileged follow-up workflow may be useful for publishing results from an unprivileged build, but it must verify:
+
+- The upstream workflow identity.
+- The event and branch that produced the run.
+- The exact source commit.
+- The upstream conclusion.
+- The artifact name, digest, expected files, and content constraints.
+- That artifacts or caches cannot overwrite trusted executable paths.
+
+Use a protected environment for the privileged operation and prefer attestations or signed provenance for high-value releases.
+
+## 5. Actions and Workflow Dependencies
+
+### 5.1. Pinning
+
+Pin every external action and cross-repository reusable workflow to a verified full-length commit SHA.
+
+```yaml
+- uses: actions/checkout@<full-length-commit-sha> # v4
+```
+
+A tag or branch can move. Keep the human-readable release in a comment and use dependency automation to propose reviewed SHA updates.
+
+For local actions and same-repository reusable workflows, the caller and callee come from the same commit when using a relative path.
+
+### 5.2. Dependency Review
+
+Before adopting an action or workflow, inspect:
+
+- Ownership and publisher identity.
+- Source code and generated distribution files.
+- Requested token permissions.
+- Secret and environment access.
+- Network destinations.
+- Runtime and transitive package dependencies.
+- Release process, maintenance activity, and security policy.
+- Input handling and shell execution.
+- Whether the action modifies git configuration, credentials, workspace files, or runner state.
+
+### 5.3. Checkout
+
+Disable persisted credentials unless later steps require authenticated Git operations:
+
+```yaml
+- uses: actions/checkout@<full-length-commit-sha> # v4
+  with:
+    persist-credentials: false
+```
+
+Set `fetch-depth` only as deep as required. Fetching full history increases time and exposure without benefit when the job only needs the current commit.
+
+### 5.4. Dependency Updates
+
+Configure Dependabot for the `github-actions` ecosystem or an equivalent reviewed update process. Review changed SHAs, release notes, source diffs, permissions, and runtime changes before merging.
+
+## 6. Secrets, OIDC, and Environments
+
+### 6.1. Secret Rules
+
+- Store one logical secret per value rather than structured blobs when practical.
+- Scope secrets to the narrowest repository, environment, or organization audience.
+- Do not pass secrets to jobs that execute untrusted code.
+- Do not expose secrets through command arguments, process lists, debug output, artifacts, caches, summaries, or generated files.
+- Register derived sensitive values for masking when they may appear in logs.
+- Rotate a secret immediately after suspected exposure; deleting a log is not sufficient.
+- Treat secret redaction as pattern matching that can fail after transformation.
+
+### 6.2. OIDC
+
+Prefer OIDC for cloud providers and services that support it.
+
+```yaml
+jobs:
+  deploy:
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Authenticate to cloud provider
+        uses: provider/login-action@<full-length-commit-sha> # v3
+        with:
+          role: production-deployer
+```
+
+The cloud trust policy should restrict claims such as:
+
+- Repository identity.
+- Repository owner or organization.
+- Branch, tag, or protected environment.
+- Reusable workflow identity.
+- Audience.
+- Repository visibility or custom properties where supported.
+
+Grant a short session with a narrowly scoped role. Do not trust only the organization when a specific repository or workflow is required.
+
+### 6.3. Environments
+
+Use environments to gate sensitive jobs:
+
+```yaml
+jobs:
+  deploy:
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
+```
+
+Configure protection rules outside the workflow:
+
+- Required reviewers.
+- Allowed branches or tags.
+- Wait timers where appropriate.
+- Environment-scoped secrets and variables.
+- Custom protection rules when available.
+
+Remember that reusable workflow callers cannot pass environment secrets through `workflow_call`; environment selection in the called job determines the environment secret source.
+
+## 7. Runners
+
+### 7.1. GitHub-Hosted Runners
+
+Prefer GitHub-hosted runners for untrusted or general workloads because they are ephemeral for each job. Still assume the job can access all data provided to that runner during execution.
+
+- Do not expose unnecessary secrets.
+- Review runner-image updates.
+- Pin toolchains where reproducibility matters.
+- Avoid relying on undocumented preinstalled software.
+
+### 7.2. Self-Hosted Runners
+
+Do not use self-hosted runners for untrusted public pull requests.
+
+For private workloads, require:
+
+- Ephemeral or just-in-time runner lifecycle where possible.
+- Clean machine or virtual-machine state for every job.
+- Dedicated runner groups and repository allow lists.
+- Minimal host credentials and no developer keys.
+- Restricted network routes and metadata-service access.
+- No shared writable workspace between trust domains.
+- Centralized patching, logging, inventory, and incident response.
+- Capacity controls that prevent concurrent jobs from observing each other.
+
+A container alone is not a sufficient isolation boundary for hostile workflow code.
+
+## 8. Caches and Artifacts
+
+### 8.1. Cache Threats
+
+Caches are mutable optimization data. A less-trusted workflow may poison content later restored by a privileged workflow.
+
+Controls:
+
+- Separate keys by trust level, branch, operating system, architecture, and lock-file state.
+- Avoid broad restore keys in privileged workflows.
+- Never execute cached binaries or scripts in a privileged context without verification.
+- Never cache credentials or deployment state.
+- Prefer reinstalling security-sensitive dependencies from a verified lock file.
+
+### 8.2. Artifact Threats
+
+Artifacts can contain executable files, archives, symlinks, path traversal entries, unexpected file types, or replaced outputs.
+
+Controls:
+
+- Verify the producing workflow, run, branch, commit, and conclusion.
+- Download only the expected artifact by exact name.
+- Enforce size and file-count limits.
+- Extract into an isolated directory with path traversal and symlink checks.
+- Verify checksums, signatures, or attestations.
+- Do not place untrusted artifact contents over scripts, tool directories, or the workspace used by privileged steps.
+
+## 9. Release and Deployment Integrity
+
+For release and deployment workflows:
+
+1. Build once from a reviewed source commit.
+2. Produce immutable artifacts with digests.
+3. Run tests and scans against those exact artifacts.
+4. Create attestations or provenance where supported.
+5. Require protected-environment approval for sensitive targets.
+6. Authenticate with OIDC or another short-lived credential.
+7. Deploy or publish the exact verified artifact.
+8. Record commit, digest, workflow run, environment, and result.
+9. Define rollback to a known artifact rather than rebuilding old source.
+
+Do not publish from a pull request workflow or from a mutable branch reference without a reviewed trust path.
+
+## 10. Security Review Procedure
+
+1. Enumerate all triggers and actors that can invoke them.
+2. Identify the checked-out ref and code provenance in every job.
+3. Mark every expression that can contain attacker-controlled data.
+4. Record workflow- and job-level permissions.
+5. Record secrets, environment access, and OIDC permissions.
+6. List external actions, reusable workflows, containers, and package installation commands.
+7. Verify full-SHA pins and publisher provenance.
+8. Inspect caches, artifacts, job outputs, and cross-workflow data flows.
+9. Review runner persistence and network reachability.
+10. Test fork, cancellation, rerun, and failed-upstream behavior.
+11. Confirm environment protections and rollback.
+12. Run static and security analysis.
+
+## 11. Common Mistakes
+
+- Setting `permissions: write-all` to fix an authorization error.
+- Granting `id-token: write` globally.
+- Assuming a secret is safe because logs usually redact it.
+- Using `pull_request_target` to build a contributor's code.
+- Interpolating pull request or issue text directly into Bash or PowerShell.
+- Pinning only third-party actions while leaving first-party actions mutable.
+- Trusting an artifact because it came from another workflow in the same repository.
+- Restoring a pull-request cache in a privileged release job.
+- Using a shared persistent runner across repositories with different trust levels.
+- Storing cloud access keys when OIDC is available.
+- Rebuilding after approval instead of promoting the reviewed artifact.
+- Allowing workflow changes without designated review or code ownership.
+
+## 12. References
+
+- GitHub Docs: [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- GitHub Docs: [OpenID Connect](https://docs.github.com/en/actions/concepts/security/openid-connect)
+- GitHub Docs: [Use GITHUB_TOKEN for authentication in workflows](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token)
+- GitHub Docs: [Securely using pull_request_target](https://docs.github.com/en/actions/reference/security/secure-use#using-the-pull_request_target-event)
+- GitHub Docs: [Deployments and environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)
+- GitHub Docs: [Self-hosted runners reference](https://docs.github.com/en/actions/reference/runners/self-hosted-runners)
+- GitHub Docs: [Using artifact attestations to establish provenance for builds](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/establish-provenance)

--- a/skills/github-actions/references/testing-and-troubleshooting.md
+++ b/skills/github-actions/references/testing-and-troubleshooting.md
@@ -1,0 +1,431 @@
+# Testing and Troubleshooting
+
+> **Part of:** [GitHub Actions](../SKILL.md)
+> **Purpose:** Validation layers, static analysis, GitHub-side testing, debugging, and failure playbooks
+
+- [1. Validation Ladder](#1-validation-ladder)
+- [2. Static Validation](#2-static-validation)
+- [3. Security Validation](#3-security-validation)
+- [4. GitHub-Side Testing](#4-github-side-testing)
+- [5. Debug Logging](#5-debug-logging)
+- [6. Failure Diagnosis](#6-failure-diagnosis)
+- [7. Flaky and Slow Workflows](#7-flaky-and-slow-workflows)
+- [8. Safe Reruns and Recovery](#8-safe-reruns-and-recovery)
+- [9. Review Checklist](#9-review-checklist)
+- [10. Common Mistakes](#10-common-mistakes)
+- [11. References](#11-references)
+
+## 1. Validation Ladder
+
+Validate from cheapest and most deterministic to most integrated:
+
+1. Repository conventions and changed-file review.
+2. YAML 1.2 syntax and local path validation.
+3. GitHub Actions semantic linting.
+4. Embedded shell and language linting.
+5. Security analysis.
+6. Unit tests for scripts, custom actions, and generated matrices.
+7. Representative GitHub-hosted workflow runs.
+8. Fork, permission, environment, cancellation, rerun, and rollback tests.
+9. Production-like canary or non-production deployment.
+
+A successful YAML parse does not prove that GitHub accepts the workflow or that the workflow is secure.
+
+## 2. Static Validation
+
+### 2.1. Changed Files
+
+Inspect the complete diff, including:
+
+- `.github/workflows/*.yml` and `.yaml`.
+- `.github/actions/**/action.yml` and `.yaml`.
+- Scripts called by workflows.
+- Dependency lock files.
+- Dockerfiles and container references.
+- CODEOWNERS, Dependabot, and repository policy files.
+- Deployment manifests and infrastructure code.
+
+Workflow behavior often changes through scripts or configuration outside `.github/workflows/`.
+
+### 2.2. Actionlint
+
+Use `actionlint` to validate workflow syntax, expressions, contexts, job dependencies, runner labels, and embedded shell integration.
+
+```bash
+actionlint
+```
+
+With ShellCheck available:
+
+```bash
+actionlint -shellcheck shellcheck
+```
+
+Run against changed files when the repository is large:
+
+```bash
+actionlint .github/workflows/pull-request-ci.yml
+```
+
+Do not suppress a rule without documenting why the workflow remains correct.
+
+### 2.3. YAML Validation
+
+Use a YAML 1.2-aware parser. YAML 1.1 parsers may incorrectly treat the key `on` as a Boolean. Verify:
+
+- No duplicate keys.
+- Indentation and scalar style.
+- Quoted version values in matrices.
+- Correct expression delimiters.
+- Valid local action and reusable workflow paths.
+
+### 2.4. Embedded Code
+
+Run the native linter for every language embedded or invoked by the workflow:
+
+```bash
+shellcheck scripts/*.sh
+```
+
+```powershell
+Invoke-ScriptAnalyzer -Path scripts -Recurse
+```
+
+Test scripts independently with controlled environment variables and temporary directories.
+
+### 2.5. Composite Actions
+
+Validate `action.yml` or `action.yaml`:
+
+- Required top-level `name`, `description`, and `runs` fields.
+- Input and output descriptions.
+- `runs.using: composite` for composite actions.
+- Explicit shell on every `run` step.
+- Correct use of `$GITHUB_ACTION_PATH`.
+- No hidden assumptions about caller permissions, working directory, or operating system.
+
+## 3. Security Validation
+
+Review or scan for:
+
+- Mutable external action or reusable workflow references.
+- Excessive workflow or job permissions.
+- Direct expression interpolation into `run:`.
+- Unsafe `pull_request_target` or `workflow_run` code checkout.
+- Secrets exposed to untrusted code.
+- OIDC permission or trust-policy overreach.
+- Cache poisoning and unsafe artifact extraction.
+- Self-hosted runners reachable by untrusted events.
+- Checkout credential persistence.
+- Unbounded network downloads or execution of generated code.
+- Release or deployment from an unreviewed source.
+
+Use CodeQL workflow analysis, OpenSSF Scorecard, and a dedicated workflow security scanner when supported by the repository.
+
+Static findings are signals. Review event context and data flow before suppressing or accepting a result.
+
+## 4. GitHub-Side Testing
+
+### 4.1. Inspect Workflow Definitions
+
+With GitHub CLI:
+
+```bash
+gh workflow list
+```
+
+```bash
+gh workflow view pull-request-ci.yml --yaml
+```
+
+The repository default branch may determine which workflow definitions are discoverable for manual dispatch.
+
+### 4.2. Manual Dispatch
+
+For workflows that support `workflow_dispatch`:
+
+```bash
+gh workflow run deploy.yml \
+  --ref feature/test-workflow \
+  -f environment=staging \
+  -f dry_run=true
+```
+
+Use a non-production environment and non-privileged credentials for initial validation.
+
+### 4.3. Observe Runs
+
+```bash
+gh run list --workflow pull-request-ci.yml
+```
+
+```bash
+gh run watch <run-id> --exit-status
+```
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+Inspect the event, source branch, source commit, actor, permissions, runner labels, job graph, artifacts, environment approvals, and conclusion.
+
+### 4.4. Test Matrix
+
+For meaningful changes, test:
+
+| Path | Why |
+|---|---|
+| Success | Baseline correctness |
+| Expected test failure | Failure propagation and summaries |
+| Cancelled run | Cleanup and concurrency behavior |
+| Rerun failed jobs | Idempotency and external side effects |
+| Fork pull request | Token, secret, and untrusted-code safety |
+| Internal pull request | Repository-specific permissions |
+| Default-branch push | Trusted branch behavior |
+| Tag or release | Release filter correctness |
+| Protected environment | Approval and secret gating |
+| Merge queue | Required-check compatibility |
+
+### 4.5. Local Emulation
+
+Local workflow emulators can shorten feedback for simple shell and container jobs, but they are not authoritative for:
+
+- GitHub token permissions.
+- Fork security behavior.
+- Hosted runner images.
+- Environments and protection rules.
+- OIDC claims.
+- Reusable workflow edge cases.
+- Service behavior and networking.
+- GitHub API event payloads.
+
+Always finish validation on GitHub for changes that depend on platform semantics.
+
+## 5. Debug Logging
+
+### 5.1. Structured Logs
+
+Use workflow commands to group related output:
+
+```bash
+echo "::group::Dependency diagnostics"
+printenv | sort
+npm --version
+echo "::endgroup::"
+```
+
+Do not print all environment variables in jobs that receive secrets. Select non-sensitive diagnostics explicitly.
+
+### 5.2. Step Summaries
+
+Write concise diagnostic and test summaries to `$GITHUB_STEP_SUMMARY`:
+
+```bash
+{
+  echo '## Test Summary'
+  echo
+  echo '- Unit tests: passed'
+  echo '- Integration tests: passed'
+} >> "$GITHUB_STEP_SUMMARY"
+```
+
+Never include secrets, signed URLs, or sensitive infrastructure details in summaries.
+
+### 5.3. Debug Flags
+
+GitHub supports runner and step debug logging through repository or organization secrets or variables such as `ACTIONS_RUNNER_DEBUG` and `ACTIONS_STEP_DEBUG` according to current platform guidance.
+
+Enable them temporarily, reproduce the issue, inspect logs for sensitive output, then disable them. Rotate any credential that may have been exposed.
+
+### 5.4. Temporary Diagnostics
+
+Temporary diagnostics should:
+
+- Be narrowly scoped.
+- Avoid secret-bearing commands.
+- Be removed before merge unless they provide durable observability.
+- Use artifact retention appropriate to the sensitivity of captured data.
+
+## 6. Failure Diagnosis
+
+### 6.1. Workflow Does Not Start
+
+Check:
+
+- File path is directly under `.github/workflows/`.
+- YAML and `on` syntax are valid.
+- Event activity type matches.
+- Branch, tag, and path filters match.
+- Workflow exists on the branch required by the event.
+- Manual workflow is enabled and visible on the default branch.
+- Repository or organization Actions policy permits referenced actions.
+- Commit message did not request a workflow skip.
+- Merge queue emits `merge_group` and the workflow handles it.
+
+### 6.2. Job Is Skipped
+
+Check:
+
+- `if` expression and implicit `success()` behavior.
+- Results of every job in `needs`.
+- Boolean versus string comparison.
+- Availability of contexts at job and step evaluation time.
+- Matrix expansion and `include` or `exclude` rules.
+- Environment protection or concurrency state.
+
+Inspect job condition logs in the GitHub UI when available.
+
+### 6.3. Permission Denied
+
+Check:
+
+- Workflow- and job-level `permissions`.
+- Repository default token policy.
+- Fork pull request token restrictions.
+- Organization policy.
+- Whether a reusable workflow caller granted the required permissions.
+- Whether the API operation requires a GitHub App or user token rather than `GITHUB_TOKEN`.
+- Environment approval and secret availability.
+
+Do not fix permission errors by granting `write-all`.
+
+### 6.4. Secret Is Empty
+
+Check:
+
+- Fork or Dependabot event restrictions.
+- Secret scope and environment selection.
+- Secret name and caller-to-reusable-workflow mapping.
+- Whether `secrets: inherit` is permitted and appropriate.
+- Whether an `if` condition attempted to reference a secret directly where unsupported.
+- Whether the secret is intentionally unavailable until environment approval.
+
+### 6.5. Expression or Output Failure
+
+Check:
+
+- Step has an `id` before referencing `steps.<id>.outputs`.
+- Producer wrote to `$GITHUB_OUTPUT`.
+- Job maps step output before caller reads `needs.<job>.outputs`.
+- Output is not secret-redacted or empty on a skipped path.
+- JSON is valid before using `fromJSON`.
+- Values are quoted when YAML might coerce numbers or Booleans.
+
+### 6.6. Cache Miss or Corruption
+
+Check:
+
+- Exact key and restore key order.
+- Lock-file hash and workspace path.
+- Operating-system and architecture dimensions.
+- Cache scope across branches.
+- Whether an untrusted run populated a broader key.
+- Whether the cached content is safe to reuse.
+
+Delete or rotate a suspect cache key rather than repeatedly restoring corrupted state.
+
+### 6.7. Artifact Missing or Unsafe
+
+Check:
+
+- Producer job completed and upload step ran.
+- Artifact name matches exactly.
+- Retention period has not expired.
+- Hidden files and path globs behave as intended.
+- Consumer selected the correct run and commit.
+- Archive extraction and digest validation are safe.
+
+## 7. Flaky and Slow Workflows
+
+### 7.1. Flakiness
+
+Classify failures before adding retries:
+
+- Product or test defect.
+- External service instability.
+- Race condition.
+- Resource exhaustion.
+- Runner image drift.
+- Dependency download or registry issue.
+- Clock, locale, time zone, or order dependence.
+- Shared-state collision.
+
+A blind retry can hide a deterministic defect or repeat an unsafe side effect.
+
+### 7.2. Performance
+
+Measure job and step duration, then optimize:
+
+- Parallelize independent jobs.
+- Reduce checkout depth.
+- Cache dependency downloads with correct keys.
+- Avoid repeated setup across jobs when a reusable artifact is safer.
+- Split fast required checks from expensive optional or scheduled checks.
+- Use matrix `max-parallel` according to runner and external-system capacity.
+- Cancel superseded pull request runs.
+- Avoid uploading large, low-value artifacts.
+
+Do not sacrifice isolation, provenance, or test coverage solely for runtime reduction.
+
+### 7.3. Timeouts
+
+Set timeouts based on observed healthy duration plus reasonable variance. A timeout should fail with enough log context to diagnose the blocked operation.
+
+## 8. Safe Reruns and Recovery
+
+Before rerunning a failed publish, release, deployment, or mutation job, determine:
+
+- Which side effects completed.
+- Whether the operation is idempotent.
+- Whether an external lock or partial deployment remains.
+- Whether a package version, tag, release, or artifact already exists.
+- Whether credentials or approvals remain valid.
+- Whether the source commit and artifact digest are unchanged.
+
+Prefer a workflow designed to detect and resume or safely reject duplicate work. Do not rerun an irreversible job until current state is reconciled.
+
+Rollback should identify:
+
+- Last known-good artifact digest.
+- Target environment or registry state.
+- Commands or workflow dispatch needed to restore it.
+- Data or schema compatibility constraints.
+- Required approvals.
+- Evidence to preserve for incident review.
+
+## 9. Review Checklist
+
+- [ ] Workflow YAML passes a YAML 1.2 parser.
+- [ ] `actionlint` passes without unexplained suppressions.
+- [ ] Shell and language linters pass.
+- [ ] Local actions, scripts, and reusable workflow paths exist.
+- [ ] External dependencies are full-SHA pinned.
+- [ ] Security analysis covers permissions, events, inputs, credentials, artifacts, caches, and runners.
+- [ ] Successful and failed GitHub-hosted runs were inspected.
+- [ ] Fork and protected-environment behavior was tested where relevant.
+- [ ] Cancellation, concurrency, and rerun behavior is safe.
+- [ ] Logs and summaries provide useful non-sensitive diagnostics.
+- [ ] Release or deployment rollback is documented.
+
+## 10. Common Mistakes
+
+- Treating YAML parse success as complete validation.
+- Using a YAML 1.1 parser that converts `on` to a Boolean.
+- Running only the happy path.
+- Debugging by printing all environment variables.
+- Adding retries before identifying the failure class.
+- Rerunning a partially completed publish or deploy without reconciling state.
+- Assuming local emulation reproduces GitHub permissions and security semantics.
+- Ignoring scripts, Dockerfiles, or lock files changed alongside workflow YAML.
+- Suppressing actionlint or security findings without a threat-model explanation.
+- Forgetting merge queue and fork pull request test cases.
+
+## 11. References
+
+- GitHub Docs: [Troubleshooting workflows](https://docs.github.com/en/actions/how-tos/troubleshoot-workflows)
+- GitHub Docs: [Using workflow run logs](https://docs.github.com/en/actions/how-tos/monitor-workflows/use-workflow-run-logs)
+- GitHub Docs: [Enabling debug logging](https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging)
+- GitHub Docs: [Re-running workflows and jobs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs)
+- GitHub CLI Manual: [`gh workflow`](https://cli.github.com/manual/gh_workflow)
+- GitHub CLI Manual: [`gh run`](https://cli.github.com/manual/gh_run)
+- Actionlint: [Static checker for GitHub Actions workflow files](https://github.com/rhysd/actionlint)

--- a/skills/github-actions/references/workflow-authoring.md
+++ b/skills/github-actions/references/workflow-authoring.md
@@ -1,0 +1,510 @@
+# Workflow Authoring
+
+> **Part of:** [GitHub Actions](../SKILL.md)
+> **Purpose:** Workflow syntax, event routing, job architecture, matrices, caching, artifacts, and concurrency
+
+- [1. Design Sequence](#1-design-sequence)
+- [2. Workflow Skeleton](#2-workflow-skeleton)
+- [3. Events and Filters](#3-events-and-filters)
+- [4. Jobs, Steps, and Conditions](#4-jobs-steps-and-conditions)
+- [5. Matrices](#5-matrices)
+- [6. Concurrency and Cancellation](#6-concurrency-and-cancellation)
+- [7. Caches and Artifacts](#7-caches-and-artifacts)
+- [8. Containers and Services](#8-containers-and-services)
+- [9. Shells and Scripts](#9-shells-and-scripts)
+- [10. CI Example](#10-ci-example)
+- [11. Common Mistakes](#11-common-mistakes)
+- [12. References](#12-references)
+
+## 1. Design Sequence
+
+Design workflows in this order:
+
+1. Define the outcome and required check names.
+2. Select events and filters.
+3. Classify trusted and untrusted inputs.
+4. Define workflow-level permissions.
+5. Draw the job dependency graph.
+6. Assign runner, environment, permissions, timeout, and concurrency to each job.
+7. Define data transfer through outputs, artifacts, or caches.
+8. Select external actions and pin them.
+9. Implement scripts and conditions.
+10. Validate success, failure, cancellation, and rerun behavior.
+
+Do not begin with a copied workflow and retrofit the threat model afterward.
+
+## 2. Workflow Skeleton
+
+A production workflow should make intent, scope, permissions, and cancellation behavior visible near the top.
+
+```yaml
+name: Pull Request CI
+
+run-name: >-
+  CI for ${{ github.event.pull_request.number || github.ref_name }}
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<full-length-commit-sha> # v4
+        with:
+          persist-credentials: false
+      - name: Run tests
+        run: ./scripts/test.sh
+```
+
+### 2.1. Ordering Convention
+
+Use a consistent top-level order:
+
+1. `name`
+2. `run-name`
+3. `on`
+4. `permissions`
+5. `concurrency`
+6. `env`
+7. `defaults`
+8. `jobs`
+
+Within a job, prefer:
+
+1. `name`
+2. `if`
+3. `needs`
+4. `runs-on` or `uses`
+5. `environment`
+6. `concurrency`
+7. `timeout-minutes`
+8. `permissions`
+9. `strategy`
+10. `container` and `services`
+11. `env` and `defaults`
+12. `outputs`
+13. `steps`, `with`, or `secrets`
+
+Consistency is more important than the exact order, provided security-sensitive settings remain easy to review.
+
+## 3. Events and Filters
+
+### 3.1. Event Selection
+
+| Event | Appropriate use | Important constraint |
+|---|---|---|
+| `pull_request` | Build and test proposed changes | Fork code is untrusted; secrets are unavailable by default |
+| `push` | Trusted branch or tag automation | Validate branch and tag filters carefully |
+| `workflow_dispatch` | Manual operation | Use typed inputs and protected environments for sensitive actions |
+| `schedule` | Periodic maintenance | Runs may be delayed; make tasks idempotent |
+| `workflow_call` | Reusable workflow entry point | Inputs and secrets form a public contract |
+| `workflow_run` | Follow-up after another workflow | Treat upstream artifacts and branch identity as untrusted until verified |
+| `pull_request_target` | Base-repository metadata automation | Never execute or check out untrusted PR code in the privileged context |
+| `merge_group` | Merge queue validation | Include when required checks must run in a merge queue |
+
+### 3.2. Filters
+
+- Use `branches` and `tags` to narrow trusted release paths.
+- Use `paths` only when skipped checks will not block required-status behavior.
+- Remember that branch and path filters are combined with logical AND when both are present.
+- Keep negative patterns after positive patterns when exclusion order matters.
+- Include workflow files, build scripts, lock files, and shared configuration in path filters when they affect the result.
+
+### 3.3. Required-Check Stability
+
+A workflow skipped by branch or path filtering can leave an expected check pending. For monorepos or heavily conditional pipelines, use one of these patterns:
+
+- Make the required workflow always start and decide work at the job level.
+- Add a stable aggregation job that always reports the final result.
+- Use separate required checks per component only when branch protection can model them accurately.
+- Avoid renaming required workflow or job checks without coordinating branch protection changes.
+
+### 3.4. Manual Inputs
+
+Use typed inputs and validate semantic constraints in the first job.
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment target
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      dry_run:
+        description: Plan without applying
+        required: true
+        default: true
+        type: boolean
+```
+
+Do not use free-form manual input for a branch, environment, command, or file path without strict validation.
+
+## 4. Jobs, Steps, and Conditions
+
+### 4.1. Job Graph
+
+Use `needs` to encode dependencies and make outputs explicit.
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-name: ${{ steps.meta.outputs.artifact-name }}
+    steps:
+      - id: meta
+        run: echo "artifact-name=package-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+  verify:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf '%s\n' '${{ needs.build.outputs.artifact-name }}'
+```
+
+Keep job outputs small and non-sensitive. Use artifacts for files and external stores for large or durable data.
+
+### 4.2. Conditions
+
+- Prefer job-level `if` when an entire job is optional.
+- Prefer step-level `if` for local branching within a job.
+- Treat all values from `github.event` as untrusted strings unless documented otherwise.
+- Use status functions deliberately: `success()`, `failure()`, `cancelled()`, and `always()`.
+- For cleanup, prefer a condition that does not run after cancellation when continued execution would be unsafe.
+- Avoid complex expressions duplicated across jobs; compute a validated decision once and expose it as an output.
+
+### 4.3. Check Aggregation
+
+A stable final check is useful when jobs are conditional or matrix-generated.
+
+```yaml
+jobs:
+  lint:
+    # ...
+
+  test:
+    # ...
+
+  ci-result:
+    name: CI Result
+    if: ${{ !cancelled() }}
+    needs:
+      - lint
+      - test
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify required jobs
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          test "$LINT_RESULT" = success
+          test "$TEST_RESULT" = success
+```
+
+Account for intentionally skipped jobs when implementing an aggregator.
+
+## 5. Matrices
+
+Use matrices for the Cartesian product of a coherent test dimension such as operating system, language version, database version, or feature flag.
+
+```yaml
+strategy:
+  fail-fast: false
+  max-parallel: 6
+  matrix:
+    os:
+      - ubuntu-latest
+      - windows-latest
+    runtime:
+      - "20"
+      - "22"
+    include:
+      - os: ubuntu-latest
+        runtime: "22"
+        coverage: true
+```
+
+### 5.1. Matrix Rules
+
+- Quote version-like values to prevent YAML numeric coercion.
+- Use `include` for exceptional combinations and added metadata.
+- Use `exclude` only for known-invalid combinations; document why.
+- Use `max-parallel` to protect rate-limited or stateful dependencies.
+- Avoid placing deployment environments in a broad matrix unless protection and concurrency are defined per target.
+- Do not use a matrix when a generated list would be attacker-controlled without validation.
+
+## 6. Concurrency and Cancellation
+
+### 6.1. Supersedable Validation
+
+```yaml
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+This cancels stale validation for the same pull request or branch.
+
+### 6.2. Serialized Deployment
+
+```yaml
+jobs:
+  deploy:
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
+```
+
+Use a stable group per target. Do not cancel an in-progress irreversible deployment unless the deployment system supports safe interruption and recovery.
+
+### 6.3. Concurrency Rules
+
+- Include the workflow name in broad repository-level groups to avoid accidental cross-workflow cancellation.
+- Normalize case-sensitive input before using it in a group when multiple spellings could refer to one target.
+- Do not include secrets in concurrency expressions.
+- Design teardown and state locks for cancelled runs.
+
+## 7. Caches and Artifacts
+
+### 7.1. Decision Table
+
+| Requirement | Use |
+|---|---|
+| Speed up repeated dependency downloads | Cache |
+| Pass files between jobs in one run | Artifact |
+| Retain test reports or release evidence | Artifact |
+| Publish a release deliverable | Release/package registry plus digest |
+| Share mutable state | External state service, not cache |
+
+### 7.2. Cache Rules
+
+- Never cache secrets, credentials, signing keys, or mutable deployment state.
+- Key on operating system, architecture, toolchain, dependency manager, and lock-file hash as needed.
+- Use restore keys only when stale or broader content is safe.
+- Treat caches from untrusted workflows as potentially poisoned.
+- Do not use a cache as a provenance-bearing build artifact.
+
+Example key:
+
+```yaml
+key: >-
+  deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/package-lock.json') }}
+```
+
+### 7.3. Artifact Rules
+
+- Give artifacts deterministic names.
+- Set retention intentionally.
+- Upload only required paths and fail when critical files are missing.
+- Record checksums for release or deployment artifacts.
+- Validate file type, size, paths, and provenance before consuming artifacts in a privileged job.
+- Avoid extracting untrusted archives without zip-slip and symlink protections.
+
+## 8. Containers and Services
+
+- Pin container images by digest for security-sensitive jobs.
+- Use service containers for disposable test dependencies.
+- Add explicit health checks before tests begin.
+- Avoid mounting the Docker socket into untrusted jobs.
+- Treat container credentials as secrets and minimize registry scope.
+- Remember that Linux container jobs and service containers require Linux runners.
+
+Example service:
+
+```yaml
+services:
+  postgres:
+    image: postgres:17@sha256:<image-digest>
+    env:
+      POSTGRES_PASSWORD: test-only-password
+    ports:
+      - 5432:5432
+    options: >-
+      --health-cmd "pg_isready"
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
+```
+
+Use non-sensitive test credentials only in workflow source.
+
+## 9. Shells and Scripts
+
+### 9.1. Bash
+
+Use explicit Bash and strict handling:
+
+```yaml
+defaults:
+  run:
+    shell: bash
+```
+
+For non-trivial logic, move commands into a versioned script:
+
+```yaml
+- name: Validate project
+  env:
+    TARGET: ${{ inputs.target }}
+  run: ./scripts/validate.sh "$TARGET"
+```
+
+The script should use:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+### 9.2. PowerShell
+
+Use `pwsh`, set strict mode, and fail on errors:
+
+```powershell
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+```
+
+### 9.3. Workflow Files
+
+Use environment files:
+
+```bash
+printf 'name=%s\n' "$value" >> "$GITHUB_OUTPUT"
+printf 'KEY=%s\n' "$value" >> "$GITHUB_ENV"
+printf '%s\n' "$directory" >> "$GITHUB_PATH"
+```
+
+Generate a collision-resistant delimiter when writing multiline values. Never allow untrusted input to choose the delimiter.
+
+## 10. CI Example
+
+The following template demonstrates read-only pull request validation, matrix testing, pinned dependencies, caching, timeouts, and stable aggregation. Replace placeholder SHAs with verified full-length commit SHAs.
+
+```yaml
+name: Pull Request CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<full-length-commit-sha> # v4
+        with:
+          persist-credentials: false
+      - name: Lint
+        run: ./scripts/lint.sh
+
+  test:
+    name: Test (${{ matrix.os }}, runtime ${{ matrix.runtime }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        runtime:
+          - "20"
+          - "22"
+    steps:
+      - uses: actions/checkout@<full-length-commit-sha> # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@<full-length-commit-sha> # v4
+        with:
+          node-version: ${{ matrix.runtime }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Test
+        run: npm test
+
+  ci-result:
+    name: CI Result
+    if: ${{ !cancelled() }}
+    needs:
+      - lint
+      - test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Verify results
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          test "$LINT_RESULT" = success
+          test "$TEST_RESULT" = success
+```
+
+## 11. Common Mistakes
+
+- Assuming YAML file order controls job execution instead of using `needs`.
+- Omitting `merge_group` when merge queue requires the same checks.
+- Using path filters for a required check without a stable skipped-path design.
+- Leaving workflow or job permissions implicit.
+- Using mutable action tags without a security exception.
+- Reusing cache keys across trusted and untrusted workflows.
+- Passing files through job outputs instead of artifacts.
+- Uploading the entire workspace, including credentials or temporary files, as an artifact.
+- Using matrices for unrelated jobs or uncontrolled dynamic values.
+- Omitting timeouts from network, test, publish, or deployment jobs.
+- Embedding large scripts in YAML where they cannot be tested independently.
+- Treating `ubuntu-latest` as a fixed operating-system image.
+
+## 12. References
+
+- GitHub Docs: [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+- GitHub Docs: [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+- GitHub Docs: [Running variations of jobs in a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations)
+- GitHub Docs: [Control the concurrency of workflows and jobs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)
+- GitHub Docs: [Dependency caching reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)
+- GitHub Docs: [Store and share data with workflow artifacts](https://docs.github.com/en/actions/tutorials/store-and-share-data)


### PR DESCRIPTION
## Summary

- add a comprehensive GitHub Actions Agent Skill with a diagnose-first workflow and explicit response contract
- add focused references for workflow authoring, security hardening, reuse and architecture, and testing and troubleshooting
- register the new CI/CD skill in `.agentskills.yml`, `AGENTS.md`, and the repository catalogs

## Coverage

- event and trust-boundary selection
- least-privilege `GITHUB_TOKEN` permissions
- full-commit-SHA dependency pinning
- safe pull request and `workflow_run` handling
- OIDC, protected environments, runners, caches, artifacts, releases, and deployments
- reusable workflows, composite actions, templates, matrices, concurrency, and failure diagnosis

## Validation

- parsed the Skill frontmatter and `.agentskills.yml`
- verified Agent Skills naming, directory, description-length, metadata, and main-file-size constraints
- checked relative links, table-of-contents anchors, fenced blocks, heading structure, trailing whitespace, tabs, and final newlines
- reviewed the final branch comparison against `main`

`markdownlint` and `actionlint` were not available in the execution environment, so those repository-native checks remain for CI or reviewer execution.